### PR TITLE
Introduce request.parameters and request.attributes

### DIFF
--- a/rivr/http.py
+++ b/rivr/http.py
@@ -36,11 +36,11 @@ class Request(object):
     view gets passed the clients request.
     """
 
-    def __init__(self, path='/', method='GET', parameters=None, attributes=None,
+    def __init__(self, path='/', method='GET', query_parameters=None, attributes=None,
                  headers=None):
         self.path = path
         self.method = method
-        self.parameters = parameters or {}
+        self.query_parameters = query_parameters or {}
         self.attributes = attributes or {}
         self.headers = headers or {}
 

--- a/rivr/http.py
+++ b/rivr/http.py
@@ -36,12 +36,12 @@ class Request(object):
     view gets passed the clients request.
     """
 
-    def __init__(self, path='/', method='GET', get=None, post=None,
+    def __init__(self, path='/', method='GET', get=None, attributes=None,
                  headers=None):
         self.path = path
         self.method = method
         self.GET = get or {}
-        self.POST = post or {}
+        self.attributes = attributes or {}
         self.headers = headers or {}
 
     @property

--- a/rivr/http.py
+++ b/rivr/http.py
@@ -36,11 +36,11 @@ class Request(object):
     view gets passed the clients request.
     """
 
-    def __init__(self, path='/', method='GET', get=None, attributes=None,
+    def __init__(self, path='/', method='GET', parameters=None, attributes=None,
                  headers=None):
         self.path = path
         self.method = method
-        self.GET = get or {}
+        self.parameters = parameters or {}
         self.attributes = attributes or {}
         self.headers = headers or {}
 

--- a/rivr/tests.py
+++ b/rivr/tests.py
@@ -5,13 +5,8 @@ class TestClient(object):
     def __init__(self, handler):
         self.handler = handler
 
-    def http(self, method, path, data=None, headers=None):
-        if method == 'GET':
-            get = data
-        else:
-            get = {}
-
-        request = Request(path, method, get, data, headers)
+    def http(self, method, path, parameters=None, attributes=None, headers=None):
+        request = Request(path, method, parameters, attributes, headers)
 
         return self.handler(request)
 

--- a/rivr/tests.py
+++ b/rivr/tests.py
@@ -5,8 +5,8 @@ class TestClient(object):
     def __init__(self, handler):
         self.handler = handler
 
-    def http(self, method, path, parameters=None, attributes=None, headers=None):
-        request = Request(path, method, parameters, attributes, headers)
+    def http(self, method, path, query_parameters=None, attributes=None, headers=None):
+        request = Request(path, method, query_parameters, attributes, headers)
 
         return self.handler(request)
 

--- a/rivr/wsgi.py
+++ b/rivr/wsgi.py
@@ -151,12 +151,17 @@ class WSGIRequest(object):
 
         return self.environ['wsgi.input']
 
-    #@property
-    def get_get(self):
-        if not hasattr(self, '_get'):
-            self._get = dict((k, v) for k, v in parse_qsl(self.environ.get('QUERY_STRING', ''), True))
-        return self._get
-    GET = property(get_get)
+    @property
+    def parameters(self):
+        """
+        A dictionary containing the query parameters from the request.
+        """
+        if not hasattr(self, '_parameters'):
+            self._parameters = dict((k, v) for k, v in parse_qsl(self.environ.get('QUERY_STRING', ''), True))
+        return self._parameters
+
+    # GET is deprecated
+    GET = parameters
 
     @property
     def attributes(self):

--- a/rivr/wsgi.py
+++ b/rivr/wsgi.py
@@ -158,9 +158,15 @@ class WSGIRequest(object):
         return self._get
     GET = property(get_get)
 
-    #@property
-    def get_post(self):
-        if not hasattr(self, '_post'):
+    @property
+    def attributes(self):
+        """
+        A request body, deserialized as a dictionary.
+
+        This will automatically deserialize form or JSON encoded request bodies.
+        """
+
+        if not hasattr(self, '_attributes'):
             if self.content_length > 0:
                 content_type = self.environ.get('CONTENT_TYPE',
                                                 'application/json')
@@ -168,14 +174,17 @@ class WSGIRequest(object):
                 content = self.body.read(self.content_length)
 
                 if content_type in JSON_CONTENT_TYPES:
-                    self._post = JSONDecoder().decode(content)
+                    self._attributes = JSONDecoder().decode(content)
                 else:
                     data = parse_qsl(content, True)
-                    self._post = dict((k, v) for k, v in data)
+                    self._attributes = dict((k, v) for k, v in data)
             else:
-                self._post = {}
-        return self._post
-    POST = property(get_post)
+                self._attributes = {}
+
+        return self._attributes
+
+    # POST is deprecated
+    POST = attributes
 
     #@property
     def get_cookies(self):

--- a/rivr/wsgi.py
+++ b/rivr/wsgi.py
@@ -152,16 +152,16 @@ class WSGIRequest(object):
         return self.environ['wsgi.input']
 
     @property
-    def parameters(self):
+    def query_parameters(self):
         """
         A dictionary containing the query parameters from the request.
         """
-        if not hasattr(self, '_parameters'):
-            self._parameters = dict((k, v) for k, v in parse_qsl(self.environ.get('QUERY_STRING', ''), True))
-        return self._parameters
+        if not hasattr(self, '_query_parameters'):
+            self._query_parameters = dict((k, v) for k, v in parse_qsl(self.environ.get('QUERY_STRING', ''), True))
+        return self._query_parameters
 
     # GET is deprecated
-    GET = parameters
+    GET = query_parameters
 
     @property
     def attributes(self):

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -6,6 +6,7 @@ from rivr.tests import TestClient
 class TestClientTests(unittest.TestCase):
     def setUp(self):
         def view(request):
+            self.request = request
             return Response('{} {}'.format(request.method, request.path))
 
         self.client = TestClient(view)
@@ -29,3 +30,13 @@ class TestClientTests(unittest.TestCase):
     def test_delete(self):
         response = self.client.delete('/resource')
         self.assertEqual(response.content, 'DELETE /resource')
+
+    #
+
+    def test_parameters(self):
+        response = self.client.post('/resource', parameters={'id': 1})
+        self.assertEqual(self.request.parameters, {'id': 1})
+
+    def test_attributes(self):
+        response = self.client.post('/resource', attributes={'id': 1})
+        self.assertEqual(self.request.attributes, {'id': 1})

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -33,9 +33,9 @@ class TestClientTests(unittest.TestCase):
 
     #
 
-    def test_parameters(self):
-        response = self.client.post('/resource', parameters={'id': 1})
-        self.assertEqual(self.request.parameters, {'id': 1})
+    def test_query_parameters(self):
+        response = self.client.post('/resource', query_parameters={'id': 1})
+        self.assertEqual(self.request.query_parameters, {'id': 1})
 
     def test_attributes(self):
         response = self.client.post('/resource', attributes={'id': 1})

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -100,6 +100,22 @@ class WSGIRequestTest(unittest.TestCase):
 
         self.assertEqual(request.body.read(), 'Hi')
 
+    # Parameters
+
+    def testParameters(self):
+        request = WSGIRequest({
+            'QUERY_STRING': 'key=value',
+        })
+
+        self.assertEqual(request.parameters, {'key': 'value'})
+
+    def testDepreactedGETReturnsQueryParameters(self):
+        request = WSGIRequest({
+            'QUERY_STRING': 'key=value',
+        })
+
+        self.assertEqual(request.GET, {'key': 'value'})
+
     # Attributes
 
     def testPOSTIsAliasedToAttributes(self):

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -102,14 +102,14 @@ class WSGIRequestTest(unittest.TestCase):
 
     # Parameters
 
-    def testParameters(self):
+    def test_parameters(self):
         request = WSGIRequest({
             'QUERY_STRING': 'key=value',
         })
 
         self.assertEqual(request.parameters, {'key': 'value'})
 
-    def testDepreactedGETReturnsQueryParameters(self):
+    def test_deprecated_GET_returns_parameters(self):
         request = WSGIRequest({
             'QUERY_STRING': 'key=value',
         })
@@ -118,14 +118,14 @@ class WSGIRequestTest(unittest.TestCase):
 
     # Attributes
 
-    def testPOSTIsAliasedToAttributes(self):
+    def test_deprecated_POST_returns_attributes(self):
         # POST is deprecated, but for now is an alias for attributes
         wsgi_input = StringIO('Hi')
         request = WSGIRequest({})
 
         self.assertEqual(request.POST, {})
 
-    def testJSONHTTPBodyDataDeserialisation(self):
+    def test_parameters_deserializes_JSON_HTTP_body(self):
         wsgi_input = StringIO('{"test": "👍"}')
         request = WSGIRequest({
             'CONTENT_TYPE': 'application/json',

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -100,16 +100,16 @@ class WSGIRequestTest(unittest.TestCase):
 
         self.assertEqual(request.body.read(), 'Hi')
 
-    # Parameters
+    # Query Parameters
 
-    def test_parameters(self):
+    def test_query_parameters(self):
         request = WSGIRequest({
             'QUERY_STRING': 'key=value',
         })
 
-        self.assertEqual(request.parameters, {'key': 'value'})
+        self.assertEqual(request.query_parameters, {'key': 'value'})
 
-    def test_deprecated_GET_returns_parameters(self):
+    def test_deprecated_GET_returns_query_parameters(self):
         request = WSGIRequest({
             'QUERY_STRING': 'key=value',
         })

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -100,16 +100,22 @@ class WSGIRequestTest(unittest.TestCase):
 
         self.assertEqual(request.body.read(), 'Hi')
 
-    # POST Data
+    # Attributes
 
-    def testJSONPostDataDeserialisation(self):
+    def testPOSTIsAliasedToAttributes(self):
+        # POST is deprecated, but for now is an alias for attributes
+        wsgi_input = StringIO('Hi')
+        request = WSGIRequest({})
+
+        self.assertEqual(request.POST, {})
+
+    def testJSONHTTPBodyDataDeserialisation(self):
         wsgi_input = StringIO('{"test": "👍"}')
         request = WSGIRequest({
             'CONTENT_TYPE': 'application/json',
             'CONTENT_LENGTH': 16,
             'wsgi.input': wsgi_input,
         })
-        post = request.POST
 
-        self.assertEqual(post, {'test': '👍'})
+        self.assertEqual(request.attributes, {'test': '👍'})
 


### PR DESCRIPTION
This deprecates, because the query/attributes are not tied to a particular HTTP method. This was poor design from the start (Django still does this):
- `request.GET`
- `request.POST`

Replaces them with:
- `request.parameters` (A dictionary containing the query parameters from the request)
- `request.attributes` (A request body, deserialized as a dictionary)
